### PR TITLE
Fix prosodyctl complaining about directory owner

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -27,6 +27,8 @@ ynh_backup --src_path="$config_path"
 
 ynh_backup --src_path="$data_dir" --is_big
 
+ynh_backup --src_path="/var/lib/$app"
+
 #=================================================
 # SPECIFIC BACKUP
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -92,6 +92,7 @@ mkdir -p "/var/log/$app"
 chmod 750 "/var/log/$app"
 chmod -R o-rwx "/var/log/$app"
 chown -R $app:adm "/var/log/$app"
+chown -R $app:$app "/var/lib/$app"
 
 # Use logrotate to manage application logfile(s)
 ynh_use_logrotate

--- a/scripts/remove
+++ b/scripts/remove
@@ -42,6 +42,7 @@ ynh_secure_remove --file="$config_path"
 ynh_secure_remove --file="/var/log/$app"
 
 ynh_secure_remove --file="/run/$app"
+ynh_secure_remove --file="/var/lib/$app"
 ynh_secure_remove --file="/usr/bin/prosody"
 ynh_secure_remove --file="/usr/bin/prosodyctl"
 ynh_secure_remove --file="/usr/bin/prosody-migrator"

--- a/scripts/restore
+++ b/scripts/restore
@@ -51,8 +51,10 @@ chmod 750 "$config_path/certs"
 ynh_script_progression --message="Restoring the data directory..."
 
 ynh_restore_file --origin_path="$data_dir" --not_mandatory
+ynh_restore_file --origin_path="/var/lib/$app" --not_mandatory
 
 chown -R $app:$app "$data_dir"
+chown -R $app:$app "/var/lib/$app"
 
 #=================================================
 # RESTORE SYSTEMD
@@ -71,7 +73,6 @@ mkdir -p "/var/log/$app"
 chmod 750 "/var/log/$app"
 chmod -R o-rwx "/var/log/$app"
 chown -R $app:adm "/var/log/$app"
-chown -R $app:$app "/var/lib/$app"
 
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -71,6 +71,7 @@ mkdir -p "/var/log/$app"
 chmod 750 "/var/log/$app"
 chmod -R o-rwx "/var/log/$app"
 chown -R $app:adm "/var/log/$app"
+chown -R $app:$app "/var/lib/$app"
 
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,6 +112,7 @@ mkdir -p "/var/log/$app"
 chmod 750 "/var/log/$app"
 chmod -R o-rwx "/var/log/$app"
 chown -R $app:adm "/var/log/$app"
+chown -R $app:$app "/var/lib/$app"
 
 # Use logrotate to manage app-specific logfile(s)
 ynh_use_logrotate --non-append


### PR DESCRIPTION
## Problem

- Installation of Jitsi is broken for a few days, as Prosodyctl is complaining about the directory /var/lib/prosody, which is not owned by the correct user, so it won't be able to write files to it.

## Solution

- Added a `chown` so that `prosodyctl cert generate [...]` works. It seems that this folder should be owned by `prosody` as explained here : https://github.com/jitsi/jitsi-meet/issues/2244.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
