### PR TITLE
Remove deprecated muc_log module

### DIFF
--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -53,9 +53,6 @@ Component "muc.__DOMAIN__" "muc"
 
   modules_enabled = {
     --"muc_limits";
-    "muc_log";
-    --"muc_log_mam";
-    --"muc_log_http";
     "vcard_muc";
     "muc_mam";
   }


### PR DESCRIPTION
## Problem

In Prosody, `muc_log` and its submodules are not a thing (anymore).

See status here: https://modules.prosody.im/mod_muc_log

## Solution

Remove those entries

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
