### PR TITLE
Fix LDAP auth config to allow any email alias to be used as JID too.

### DIFF
--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -6,15 +6,7 @@ VirtualHost "__DOMAIN__"
   }
   authentication = "ldap"
   ldap_base = "ou=users,dc=yunohost,dc=org"
-  ldap = {
-     hostname      = "localhost",
-     user = {
-       basedn        = "ou=users,dc=yunohost,dc=org",
-       filter        = "(&(objectClass=posixAccount)(mail=*@__DOMAIN__)(permission=cn=xmpp.main,ou=permission,dc=yunohost,dc=org))",
-       usernamefield = "mail",
-       namefield     = "cn",
-       },
-  }
+  ldap_filter = "(&(|(mail=$user@$host)(uid=$user))(permission=cn=xmpp.main,ou=permission,dc=yunohost,dc=org))"
 
   modules_enabled = {
     "mam";

--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -6,7 +6,7 @@ VirtualHost "__DOMAIN__"
   }
   authentication = "ldap"
   ldap_base = "ou=users,dc=yunohost,dc=org"
-  ldap_filter = "(&(|(mail=$user@$host)(uid=$user))(permission=cn=xmpp.main,ou=permission,dc=yunohost,dc=org))"
+  ldap_filter = "(&(|(mail=$user@$host)(uid=$user))(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))"
 
   modules_enabled = {
     "mam";

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -42,10 +42,11 @@ _configure_prosody() {
     chmod -R g+s /var/xmpp-upload/
 }
 
-_workaround_missing_permissions() {
+_setup_initial_app_permissions() {
     # Before fixing issue #55 (https://github.com/YunoHost-Apps/prosody_ynh/issues/55) all
     # yunohost users were allowed to use prosody, regardless of actual yunohost permissions.
-    # This workaround ensures that the permission mechanism is now really in use.
+    # This workaround ensures that the permission mechanism is now really in use, even when
+    # upgrading from an older version of the app.
 
     local verbosity=${1:-verbose}
 
@@ -55,7 +56,7 @@ _workaround_missing_permissions() {
         yunohost user permission add prosody all_users
 
         test "${verbosity}" != "quiet" && ynh_print_warn "From now on, only yunohost users with 'prosody' permission can use this service."
-        test "${verbosity}" != "quiet" && ynh_print_warn "Right now, this means **all** valid yunohost users are now given explicit permission to use prosody. You may now customize this if you want."
+        test "${verbosity}" != "quiet" && ynh_print_warn "Right now, this includes **all** valid yunohost users. You may customize this if you want."
 
         # Prevent applying this workaround again in the future
         yunohost app setting prosody _is_workaround_for_missing_permissions_already_applied -v yes

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -42,6 +42,26 @@ _configure_prosody() {
     chmod -R g+s /var/xmpp-upload/
 }
 
+_workaround_missing_permissions() {
+    # Before fixing issue #55 (https://github.com/YunoHost-Apps/prosody_ynh/issues/55) all
+    # yunohost users were allowed to use prosody, regardless of actual yunohost permissions.
+    # This workaround ensures that the permission mechanism is now really in use.
+
+    local verbosity=${1:-verbose}
+
+    if [ "$(yunohost app setting prosody _is_workaround_for_missing_permissions_already_applied)" != "yes" ] ; then
+        test "${verbosity}" != "quiet" && ynh_print_warn "Applying workaround for missing yunohost permissions..."
+
+        yunohost user permission add prosody all_users
+
+        test "${verbosity}" != "quiet" && ynh_print_warn "From now on, only yunohost users with 'prosody' permission can use this service."
+        test "${verbosity}" != "quiet" && ynh_print_warn "Right now, this means **all** valid yunohost users are now given explicit permission to use prosody. You may now customize this if you want."
+
+        # Prevent applying this workaround again in the future
+        yunohost app setting prosody _is_workaround_for_missing_permissions_already_applied -v yes
+    fi
+}
+
 #=================================================
 # PERSONAL HELPERS
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -100,6 +100,9 @@ fi
 #=================================================
 ynh_script_progression "Integrating service in YunoHost..."
 
+# Handle Handle special legacy situation regarding app's permissions
+_workaround_missing_permissions quiet
+
 yunohost service add $app --log="/var/log/$app/$app.log" --needs_exposed_ports $port_client $port_client2 $port_server
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -100,8 +100,8 @@ fi
 #=================================================
 ynh_script_progression "Integrating service in YunoHost..."
 
-# Handle Handle special legacy situation regarding app's permissions
-_workaround_missing_permissions quiet
+# Make sure our app is allowed for all authenticated users by default.
+_setup_initial_app_permissions quiet
 
 yunohost service add $app --log="/var/log/$app/$app.log" --needs_exposed_ports $port_client $port_client2 $port_server
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -14,8 +14,8 @@ echo "${current_version}" | grep -qE "0.12.4~ynh1([0-9]{2})" || ynh_die "Sorry b
 You must uninstall and reinstall the app.
 Don't worry, no data will be lost."
 
-# Handle Handle special legacy situation regarding app's permissions
-_workaround_missing_permissions
+# Make sure our app is allowed for all authenticated users by default.
+_setup_initial_app_permissions
 
 #=================================================
 # ADD CONFIGURATION FILES

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -14,6 +14,9 @@ echo "${current_version}" | grep -qE "0.12.4~ynh1([0-9]{2})" || ynh_die "Sorry b
 You must uninstall and reinstall the app.
 Don't worry, no data will be lost."
 
+# Handle Handle special legacy situation regarding app's permissions
+_workaround_missing_permissions
+
 #=================================================
 # ADD CONFIGURATION FILES
 #=================================================


### PR DESCRIPTION
## Problem

Migrating from metronome, some users realized they could not use secondary email addresses as their XMPP address. anymore (Cf. #55)


## Solution

Remove obsolete LDAP settings and define a proper _ldap_filter_.


## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
- [x] Fixed an issue regarding yunohost permissions (issue discovered by a beta-tester :) )


## How to test

Create a mail alias in yunohost and try using it as XMPP account.

```bash
# fresh install
yunohost app install --force --debug \
 https://github.com/YunoHost-Apps/prosody_ynh/tree/allow-mailaliases-as-jids

# or upgrading
yunohost app upgrade --force --debug prosody \
 --url https://github.com/YunoHost-Apps/prosody_ynh/tree/allow-mailaliases-as-jids
```