### PR TITLE
Enables mod_bookmarks (XEP-0411)

### DIFF
--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -15,6 +15,7 @@ VirtualHost "__DOMAIN__"
     "turn_external";
     "bosh";
     "websocket";
+    "bookmarks";
   }
 
   modules_disabled = {


### PR DESCRIPTION
I recently installed the [Monal](https://monal-im.org) client and their [Considerations for XMPP server admins](https://github.com/monal-im/Monal/wiki/Considerations-for-XMPP-server-admins#prosody) guide says that [`mod_bookmarks`](https://prosody.im/doc/modules/mod_bookmarks) should be activated

It seems pretty reasonable so i'm doing this PR for that