### PR TITLE
Fixes ynh dns config generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It shall NOT be edited by hand.
 Modern XMPP communication server
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://prosody.im/)
-[![Version: 0.12.4~ynh102](https://img.shields.io/badge/Version-0.12.4~ynh102-rgba(0,150,0,1)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/prosody/)
+[![Version: 0.12.4~ynh102](https://img.shields.io/badge/Version-0.12.4~ynh102-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/prosody/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/prosody"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/hooks/custom_dns_rules
+++ b/hooks/custom_dns_rules
@@ -1,5 +1,15 @@
 #! /bin/bash
 
+# This script is expected to be called xx-$app
+app=$(basename $0 | cut -d- -f2)
+domain=$(yunohost app setting $app domain)
+
+# only add subdomains to the app's domain
+if [[ "$domain"  != *"$base_domain" ]]; then
+  exit 0
+fi
+
+
 suffix="${base_domain}."
 echo "
 - name: 'xmpp-upload.${suffix}'


### PR DESCRIPTION
## Problem

- the hook is called for every domain name config generation

## Solution

- do not add the DNS records to any other domain name than the prosody one

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)