### PR TITLE
[WIP] Refactor documentations and add French translations.

### DIFF
--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -1,43 +1,18 @@
-Prosody is a modern XMPP communication server. It aims to be easy to set up and configure, and efficient with system resources. Additionally, for developers it aims to be easy to extend and give a flexible system on which to rapidly develop added functionality, or prototype new protocols.
+Prosody is a modern and lightweight XMPP communication server.
 
-ℹ️  **Important note**
+To use Prosody / XMPP, you will also need a client.
+There are a [lot of XMPP clients](https://xmpp.org/software/?category=clients) available out there, but here are some recommendations, depending on your device, platform and preferences:
 
-This app installs Prosody from Debian packages.
-Basically, this means that you will not benefit from the latest versions of Prosody but benefit the stability and security of the Debian packaging.
-Read more about this decision in [RATIONALE.md](https://github.com/YunoHost-Apps/prosody_ynh/tree/stable/RATIONALE.md)
+- [Conversations](https://conversations.im/) - Android
+- [Movim](https://movim.eu) - Web - available as a YunoHost app
+- [ConverseJS](https://conversejs.org) - Web - available as a YunoHost app
+- [Gajim](https://gajim.org/) - Linux, Windows
+- [Dino](https://dino.im) - Linux
+- [Monal](https://monal-im.org/) - iOS, macOS
+- [Profanity](https://profanity-im.github.io/) - Linux console
+- [Poezio](https://poez.io/) - Linux console
 
-🚀 Target is to provide at least:
-  * A/V calls (https://github.com/YunoHost/issues/issues/1607) 
-  * BOSH (https://forum.yunohost.org/t/unable-to-set-up-bosh-conf-nginx/12995)
-  * invite links (if not covered by https://github.com/YunoHost/issues/issues/1677)
-  * File sharing for all usual filetypes (https://forum.yunohost.org/t/metronome-mime-types-for-metronome-again/20073)
-
-...and ultimately an Advanced Server compliance level (https://xmpp.org/extensions/xep-0479.html).
-
-✅ What works:
-  * install on YunoHost 12
-  * LDAP auth
-  * A/V calls
-  * File upload
-  * MUC
-  * optional import of rosters, MUCs, bookmarks from Metronome (integrated service on Yunohost 11 or app on Yunohost 12) (pep is not supported, #12)
-  * automatically install coturn if not yet present
-  * XEP-0156, XEP-0163, XEP-0191, XEP-0215, XEP-0237, XEP-0280, XEP-0313, XEP-0363 (see 'xmpp_compliance' file), XEP-0421 TBC
-
-🙋 TODO (help welcomed!):
-  * usability by other apps:
-    * [PeerTube](https://github.com/YunoHost-Apps/peertube_ynh): to be tested
-    * [Converse.js](https://github.com/YunoHost-Apps/converse_ynh): seems to work 🥳
-    * [Jitsi](https://github.com/YunoHost-Apps/jitsi_ynh): reported [to work](https://forum.yunohost.org/t/jitsi-install-fails-with-prosody-testing/35879) 🥳 
-    * [Nextcloud](https://github.com/YunoHost-Apps/nextcloud_ynh): to be tested
-    * [Libervia](https://salut-a-toi.org/): to be tested [non-working app](https://github.com/YunoHost-Apps/sat_ynh)
-    * ...?
-  * check initial configuration (DNS, ?) : information via PRE_INSTALL.md
-
-# READ before install!
-Ideally all the README :) but this in particular:
-* You must ensure that your DNS configuration includes the subdomains `muc.`, `xmpp-upload.` and `pubsub.`
-* You should **not** create Yunohost subdomains `muc.`, `xmpp-upload.` and `pubsub.`
+You will be able to connect using `your_yunohost_username@domain.tld` + your password (i.e. your credentials are the same as for email, but for instant messaging)
 
 ## App conflicts/dependencies
 **Conflict**
@@ -54,6 +29,15 @@ Ideally all the README :) but this in particular:
 # Additionnal infos
 * Users connect on XMPP with their email address. Ensure in the Yunohost Users configuration panel they have an email address matching the domain on which you install Prosody. If not add an email alias.
 
+🙋 TODO (help welcomed!):
+  * usability by other apps:
+    * [PeerTube](https://github.com/YunoHost-Apps/peertube_ynh): to be tested
+    * [Converse.js](https://github.com/YunoHost-Apps/converse_ynh): seems to work 🥳
+    * [Jitsi](https://github.com/YunoHost-Apps/jitsi_ynh): reported [to work](https://forum.yunohost.org/t/jitsi-install-fails-with-prosody-testing/35879) 🥳 
+    * [Nextcloud](https://github.com/YunoHost-Apps/nextcloud_ynh): to be tested
+    * [Libervia](https://salut-a-toi.org/): to be tested [non-working app](https://github.com/YunoHost-Apps/sat_ynh)
+    * ...?
+  * check initial configuration (DNS, ?) : information via PRE_INSTALL.md
 
-💬 Further discussions, support on xmpp:yunohost-xmpp@muc.chapril.org?join
+💬 Further discussions, support on [yunohost-xmpp@muc.chapril.org](xmpp:yunohost-xmpp@muc.chapril.org?join)
 Or in the [forum](https://forum.yunohost.org/c/apps/11).

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -1,0 +1,15 @@
+Prosody est un serveur de messagerie instantannée XMPP moderne et léger.
+
+Pour utiliser Metronome / XMPP, vous aurez également besoin d'un client.
+Il existe [beaucoup de clients XMPP](https://xmpp.org/software/?category=clients), mais voici une liste de recommandations, selon votre appareil, votre plateforme et vos préférences :
+
+- [Conversations](https://conversations.im/) - Android
+- [Movim](https://movim.eu) - Web - disponible en tant qu'app YunoHost
+- [ConverseJS](https://conversejs.org) - Web - disponible en tant qu'app YunoHost
+- [Gajim](https://gajim.org/) - Linux, Windows
+- [Dino](https://dino.im) - Linux
+- [Monal](https://monal-im.org/) - iOS, macOS
+- [Profanity](https://profanity-im.github.io/) - Linux en console
+- [Poezio](https://poez.io/) - Linux en console
+
+Vous pourrez ensuite vous connecter avec `votre_identifiant_yunohost@domaine.tld` + votre mot de passe (c-à-d vos identifiants sont les même que pour le mail, mais pour la messagerie instantannée)

--- a/manifest.toml
+++ b/manifest.toml
@@ -62,9 +62,14 @@ ram.runtime = "10M"
 
     [resources.permissions]
 
-    # Dependencies for prosodyctl install
-    # Installation of Recommends are disabled by default by some VPS providers
-    # therefore requiring explicitely here recommends for packages prosody and prosody-modules:
-    # lua5.4-event, lua5.4-readline, lua5.4-unbound, lua-ldap
+    # In Bookworm, we need to run 'prosodyctl install' which requires some extra packages.
+    # And because automatic installation of Recommends is sometimes disabled by default by some VPS providers,
+    # we need to declare here a pretty-long list of 'lua*' packages.
     [resources.apt]
-    packages = "liblua5.4-dev, lua-busted, lua5.4, lua5.4-event, lua5.4-readline, lua5.4-expat, lua5.4-socket, openssl, txt2man, lua5.4-sec, lua5.4-unbound, lua-ldap, luarocks"
+    packages_from_raw_bash="""
+        if grep -q "^VERSION_CODENAME=bookworm" /etc/os-release ; then
+            echo "prosody prosody-modules liblua5.4-dev lua-busted lua5.4 lua5.4-event lua5.4-readline lua5.4-expat lua5.4-socket openssl txt2man lua5.4-sec lua5.4-unbound lua-ldap luarocks"
+        else
+            echo "prosody prosody-modules luarocks"
+        fi
+    """

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -68,3 +68,24 @@ _setup_initial_app_permissions() {
         ynh_app_setting_set --app=prosody --key=_is_workaround_for_missing_permissions_already_applied --value=yes
     fi
 }
+
+_ensure_extra_modules_are_installed() {
+    # Some useful prosody modules may not be available in Debian repositories yet.
+    # When this is the case, we install them "manually". And when these modules are
+    # finally included in Debian, we remove the "manually" installed ones.
+    if grep -q "^VERSION_CODENAME=bookworm" /etc/os-release ; then
+        if ! prosodyctl list | grep -q ^mod_cloud_notify_extensions ; then
+            ynh_print_info "Installing mod_cloud_notify_extensions \"manually\" because it is not available in Debian Bookworm."
+            prosodyctl install --server=https://modules.prosody.im/rocks/ mod_cloud_notify_extensions
+            ynh_systemctl --service=$app --action="restart"
+        fi
+    else
+        if prosodyctl list | grep -q ^mod_cloud_notify_ ; then
+            ynh_print_info "Uninstalling mod_cloud_notify_extensions that was previously installed \"manually\". It is now included in Debian."
+            # First uninstall mod_cloud_notify_extensions, and then its dependencies
+            prosodyctl remove mod_cloud_notify_extensions
+            for mod in $(prosodyctl list | grep ^mod_cloud_notify_); do prosodyctl remove ${mod} ; done
+            ynh_systemctl --service=$app --action="restart"
+        fi
+    fi
+}

--- a/scripts/install
+++ b/scripts/install
@@ -37,10 +37,6 @@ fi
 #=================================================
 ynh_script_progression "Installing Prosody package from Debian..."
 
-# and declare the package dependency to prosody & prosody-modules
-deps=$(ynh_read_manifest "resources.apt.packages")
-ynh_apt_install_dependencies "$deps, prosody, prosody-modules"
-
 #=================================================
 # SPECIFIC SETUP
 #=================================================
@@ -112,11 +108,8 @@ ynh_systemctl --service=$app --action="restart"
 
 ynh_systemctl --service="nginx" --action="reload"
 
-# add mod_cloud_notify_extensions modules not included in Debian bookworm prosody-modules package (only in bookworm-backports)
-/usr/bin/prosodyctl install --server=https://modules.prosody.im/rocks/ mod_cloud_notify_extensions
-
-# restart to take into account new modules
-ynh_systemctl --service=$app --action="restart"
+# Make sure the expected extra prosody modules are installed, whether manually or from Debian packages.
+_ensure_extra_modules_are_installed
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/remove
+++ b/scripts/remove
@@ -15,12 +15,12 @@ if ynh_hide_warnings yunohost service status $app >/dev/null; then
 	yunohost service remove $app
 fi
 
+ynh_systemctl --service="prosody" --action="stop"
+
 rm /etc/prosody/conf.d/$domain.cfg.lua
 rm /etc/prosody/conf.avail/$domain.cfg.lua
 rm /etc/prosody/conf.d/00.cfg.lua
 rm /etc/prosody/conf.avail/00.cfg.lua
-
-DEBIAN_FRONTEND=noninteractive apt-get purge --assume-yes prosody
 
 #=================================================
 # CLEANUP NGINX CONFIG

--- a/scripts/restore
+++ b/scripts/restore
@@ -20,10 +20,6 @@ fi
 #=================================================
 ynh_script_progression "Installing Prosody package from Debian..."
 
-# and declare the package dependency to prosody & prosody-modules
-deps=$(ynh_read_manifest "resources.apt.packages")
-ynh_apt_install_dependencies "$deps, prosody, prosody-modules"
-
 #=================================================
 # SPECIFIC SETUP
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,13 +18,6 @@ Don't worry, no data will be lost."
 _setup_initial_app_permissions
 
 #=================================================
-# DECLARE PROSODY & PROSODY-MODULES DEPENDENCIES
-#=================================================
-
-deps=$(ynh_read_manifest "resources.apt.packages")
-ynh_apt_install_dependencies "$deps, prosody, prosody-modules"
-
-#=================================================
 # ADD CONFIGURATION FILES
 #=================================================
 ynh_script_progression "Configuring Prosody and NGINX..."
@@ -34,6 +27,9 @@ ynh_systemctl --service=$app --action="restart"
 prosodyctl mod_migrate_http_upload xmpp-upload.${domain} ${domain}
 # The legacy folder should now only contain empty dirs, let's remove those
 test -d /var/xmpp-upload && find /var/xmpp-upload -type d -empty -delete &> /dev/null
+
+# Make sure the expected extra prosody modules are installed, whether manually or from Debian packages.
+_ensure_extra_modules_are_installed
 
 # Add config files for prosody and nginx
 _configure_prosody


### PR DESCRIPTION
## Problem

- the app description page contains too much information, most of that information is targeted at developers or power-users
- missing translations (at least French translations, since many people I know asking for help speak French :)


## Solution

- keep technical information in English
- move technical information somewhere else (not in docs/DESCRIPTION*.md)
- for easier maintenance, the translatable docs should be kept concise, and targeted at end-users

## PR Status

- [ ] Reword DESCRIPTION (shorter, straight to the point)
- [ ] Translate DESCRIPTION
- [ ] Translate PRE_INSTALL
- [ ] Translate POST_INSTALL
