### PR TITLE
Pass XMPP Compliance Suites 2023 (0157/0065/0368/0485) + direct-TLS & SSDP hardening

### DIFF
--- a/conf/00.cfg.lua
+++ b/conf/00.cfg.lua
@@ -12,3 +12,11 @@ c2s_direct_tls_ssl = {
     certificate = "/etc/yunohost/certs/__DOMAIN__/crt.pem";
     key = "/etc/yunohost/certs/__DOMAIN__/key.pem";
 }
+
+-- Enable Direct-TLS for server-to-server on port 5270 (XEP-0368). Same
+-- certificate requirement as the c2s listener above.
+s2s_direct_tls_ports = { 5270 }
+s2s_direct_tls_ssl = {
+    certificate = "/etc/yunohost/certs/__DOMAIN__/crt.pem";
+    key = "/etc/yunohost/certs/__DOMAIN__/key.pem";
+}

--- a/conf/00.cfg.lua
+++ b/conf/00.cfg.lua
@@ -3,3 +3,12 @@ https_ports = {}
 
 -- Enable Direct-TLS on port 5223
 c2s_direct_tls_ports = { 5223 }
+
+-- The direct-TLS listener needs its own certificate (XEP-0368). STARTTLS picks
+-- the per-host cert from the stream header via SNI, but the immediate-TLS socket
+-- falls back to the global 'ssl' option, which is not set here — so without this
+-- it answers every handshake with a TLS alert. Point it at the domain cert.
+c2s_direct_tls_ssl = {
+    certificate = "/etc/yunohost/certs/__DOMAIN__/crt.pem";
+    key = "/etc/yunohost/certs/__DOMAIN__/key.pem";
+}

--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -41,10 +41,16 @@ VirtualHost "__DOMAIN__"
   turn_external_host = "__DOMAIN__"
   turn_external_port = __TURN_EXTERNAL_PORT__
 
-  contact_info = {
-    abuse = { "mailto:abuse@__DOMAIN__", "xmpp:admin@__DOMAIN__" };
-    admin = { "mailto:root@__DOMAIN__", "xmpp:admin@__DOMAIN__" };
-  };
+  -- XEP-0157 server contact info. YunoHost does not provision role aliases
+  -- (abuse@, postmaster@, root@) for a domain, so we never guess an address:
+  -- advertise only what the admin sets via the config panel (empty = none).
+  xmpp_contact_address = "__XMPP_CONTACT_ADDRESS__"
+  if xmpp_contact_address ~= "" then
+    contact_info = {
+      abuse = { xmpp_contact_address };
+      admin = { xmpp_contact_address };
+    };
+  end
 
   http_paths = {
     bosh = "/xmpp-bosh";

--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -17,6 +17,7 @@ VirtualHost "__DOMAIN__"
     "websocket";
     "csi_battery_saver";
     "server_contact_info"; -- XEP-0157: advertise abuse/admin contacts
+    "pubsub_serverinfo";   -- XEP-0485: publish server info via pubsub
   }
 
   modules_disabled = {
@@ -28,6 +29,7 @@ VirtualHost "__DOMAIN__"
   disco_items = {
     { "muc.__DOMAIN__" },
     { "pubsub.__DOMAIN__" },
+    { "proxy.__DOMAIN__" },
     --{ "jabber.__DOMAIN__" },
     --{ "vjud.__DOMAIN__" },
     { "xmpp-upload.__DOMAIN__" },
@@ -88,3 +90,8 @@ Component "xmpp-upload.__DOMAIN__" "http_file_share"
   http_paths = {
     file_share = "/upload";
   }
+
+---Set up a SOCKS5 Bytestreams file-transfer proxy (XEP-0065)
+Component "proxy.__DOMAIN__" "proxy65"
+  name = "__DOMAIN__ File Transfer Proxy"
+  proxy65_address = "proxy.__DOMAIN__"

--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -44,11 +44,14 @@ VirtualHost "__DOMAIN__"
   -- XEP-0157 server contact info. YunoHost does not provision role aliases
   -- (abuse@, postmaster@, root@) for a domain, so we never guess an address:
   -- advertise only what the admin sets via the config panel (empty = none).
-  xmpp_contact_address = "__XMPP_CONTACT_ADDRESS__"
-  if xmpp_contact_address ~= "" then
+  -- A Lua local, not a config setting: assigning a bare name here would set it
+  -- as a Prosody option, and reading it back would go through configmanager's
+  -- environment metatable rather than being a plain variable read.
+  local contact = "__XMPP_CONTACT_ADDRESS__"
+  if contact ~= "" then
     contact_info = {
-      abuse = { xmpp_contact_address };
-      admin = { xmpp_contact_address };
+      abuse = { contact };
+      admin = { contact };
     };
   end
 

--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -18,6 +18,7 @@ VirtualHost "__DOMAIN__"
     "csi_battery_saver";
     "server_contact_info"; -- XEP-0157: advertise abuse/admin contacts
     "pubsub_serverinfo";   -- XEP-0485: publish server info via pubsub
+    "sasl_ssdp";           -- XEP-0474: SASL SCRAM downgrade protection
   }
 
   modules_disabled = {

--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -16,6 +16,7 @@ VirtualHost "__DOMAIN__"
     "bosh";
     "websocket";
     "csi_battery_saver";
+    "server_contact_info"; -- XEP-0157: advertise abuse/admin contacts
   }
 
   modules_disabled = {
@@ -37,10 +38,10 @@ VirtualHost "__DOMAIN__"
   turn_external_host = "__DOMAIN__"
   turn_external_port = __TURN_EXTERNAL_PORT__
 
---  contact_info = {
---    abuse = { "mailto:abuse@__DOMAIN__", "xmpp:admin@__DOMAIN__" };
---    admin = { "mailto:root@__DOMAIN__", "xmpp:admin@__DOMAIN__" };
---  };
+  contact_info = {
+    abuse = { "mailto:abuse@__DOMAIN__", "xmpp:admin@__DOMAIN__" };
+    admin = { "mailto:root@__DOMAIN__", "xmpp:admin@__DOMAIN__" };
+  };
 
   http_paths = {
     bosh = "/xmpp-bosh";

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -55,6 +55,18 @@ services = [ "prosody", ]
         choices."999 * 365 * 24 * 60 * 60" = "999 years"
         bind = ":/etc/prosody/conf.avail/__DOMAIN__.cfg.lua"
 
+    [main.contact]
+    name.en = "Server contact"
+    name.fr = "Contact du serveur"
+
+        [main.contact.xmpp_contact_address]
+        ask.en = "Contact address (XEP-0157)"
+        ask.fr = "Adresse de contact (XEP-0157)"
+        help.en = "Advertised as the server admin/abuse contact. YunoHost does not provide role aliases like abuse@, so enter an address you actually receive (e.g. mailto:you@example.org or xmpp:you@example.org). Leave empty to advertise none."
+        type = "string"
+        default = ""
+        bind = "xmpp_contact_address:/etc/prosody/conf.avail/__DOMAIN__.cfg.lua"
+
     [main.room_default_config]
     name.en = "Room default settings"
     name.fr = "Paramètres par défaut des salons"

--- a/hooks/custom_dns_rules
+++ b/hooks/custom_dns_rules
@@ -44,4 +44,8 @@ echo "
   ttl: 3600
   type: SRV
   value: '0 5 5223 ${suffix}'
+- name: '_xmpps-server._tcp'
+  ttl: 3600
+  type: SRV
+  value: '0 5 5270 ${suffix}'
 " > ${YNH_STDRETURN}

--- a/hooks/custom_dns_rules
+++ b/hooks/custom_dns_rules
@@ -28,6 +28,10 @@ echo "
   ttl: 3600
   type: CNAME
   value: '${suffix}'
+- name: 'proxy.${suffix}'
+  ttl: 3600
+  type: CNAME
+  value: '${suffix}'
 - name: '_xmpp-client._tcp.${suffix}'
   ttl: 3600
   type: SRV

--- a/hooks/custom_dns_rules
+++ b/hooks/custom_dns_rules
@@ -32,15 +32,15 @@ echo "
   ttl: 3600
   type: CNAME
   value: '${suffix}'
-- name: '_xmpp-client._tcp.${suffix}'
+- name: '_xmpp-client._tcp'
   ttl: 3600
   type: SRV
   value: '0 5 5222 ${suffix}'
-- name: '_xmpp-server._tcp.${suffix}'
+- name: '_xmpp-server._tcp'
   ttl: 3600
   type: SRV
   value: '0 5 5269 ${suffix}'
-- name: '_xmpps-client._tcp.${suffix}'
+- name: '_xmpps-client._tcp'
   ttl: 3600
   type: SRV
   value: '0 5 5223 ${suffix}'

--- a/hooks/custom_dns_rules
+++ b/hooks/custom_dns_rules
@@ -28,4 +28,16 @@ echo "
   ttl: 3600
   type: CNAME
   value: '${suffix}'
+- name: '_xmpp-client._tcp.${suffix}'
+  ttl: 3600
+  type: SRV
+  value: '0 5 5222 ${suffix}'
+- name: '_xmpp-server._tcp.${suffix}'
+  ttl: 3600
+  type: SRV
+  value: '0 5 5269 ${suffix}'
+- name: '_xmpps-client._tcp.${suffix}'
+  ttl: 3600
+  type: SRV
+  value: '0 5 5223 ${suffix}'
 " > ${YNH_STDRETURN}

--- a/manifest.toml
+++ b/manifest.toml
@@ -59,6 +59,10 @@ ram.runtime = "10M"
     server.default = 5269
     server.exposed = "TCP"
     server.fixed = true
+    # 5000 is the SOCKS5 bytestreams file-transfer proxy (XEP-0065)
+    proxy.default = 5000
+    proxy.exposed = "TCP"
+    proxy.fixed = true
 
     [resources.permissions]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -59,6 +59,10 @@ ram.runtime = "10M"
     server.default = 5269
     server.exposed = "TCP"
     server.fixed = true
+    # 5270 is direct-TLS server-to-server (XEP-0368)
+    server2.default = 5270
+    server2.exposed = "TCP"
+    server2.fixed = true
     # 5000 is the SOCKS5 bytestreams file-transfer proxy (XEP-0065)
     proxy.default = 5000
     proxy.exposed = "TCP"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Prosody"
 description.en = "Modern XMPP communication server"
 description.fr = "Serveur de communication XMPP moderne"
 
-version = "0.12.4~ynh121"
+version = "0.12.4~ynh122"
 
 maintainers = ["yalh76", "anubister", "pitchum"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -79,6 +79,11 @@ _ensure_extra_modules_are_installed() {
             prosodyctl install --server=https://modules.prosody.im/rocks/ mod_cloud_notify_extensions
             ynh_systemctl --service=$app --action="restart"
         fi
+        if ! prosodyctl list | grep -q '^mod_server_info$' ; then
+            ynh_print_info "Installing mod_server_info \"manually\" (required by mod_pubsub_serverinfo, not in Debian Bookworm)."
+            prosodyctl install --server=https://modules.prosody.im/rocks/ mod_server_info
+            ynh_systemctl --service=$app --action="restart"
+        fi
         if ! prosodyctl list | grep -q ^mod_pubsub_serverinfo ; then
             ynh_print_info "Installing mod_pubsub_serverinfo \"manually\" because it is not available in Debian Bookworm."
             prosodyctl install --server=https://modules.prosody.im/rocks/ mod_pubsub_serverinfo

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -25,6 +25,9 @@ _configure_prosody() {
     ynh_app_setting_set_default --key=rooms_persistent --value="true"
     rooms_persistent=$(ynh_app_setting_get --key=rooms_persistent)
 
+    ynh_app_setting_set_default --key=xmpp_contact_address --value=""
+    xmpp_contact_address=$(ynh_app_setting_get --key=xmpp_contact_address)
+
     ynh_print_info "Adding Prosody configuration files..."
 
     # Add 00.cfg.lua, needed to customize some settings acrros all prosody vhosts

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -79,6 +79,11 @@ _ensure_extra_modules_are_installed() {
             prosodyctl install --server=https://modules.prosody.im/rocks/ mod_cloud_notify_extensions
             ynh_systemctl --service=$app --action="restart"
         fi
+        if ! prosodyctl list | grep -q ^mod_pubsub_serverinfo ; then
+            ynh_print_info "Installing mod_pubsub_serverinfo \"manually\" because it is not available in Debian Bookworm."
+            prosodyctl install --server=https://modules.prosody.im/rocks/ mod_pubsub_serverinfo
+            ynh_systemctl --service=$app --action="restart"
+        fi
     else
         if prosodyctl list | grep -q ^mod_cloud_notify_ ; then
             ynh_print_info "Uninstalling mod_cloud_notify_extensions that was previously installed \"manually\". It is now included in Debian."

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -89,6 +89,11 @@ _ensure_extra_modules_are_installed() {
             prosodyctl install --server=https://modules.prosody.im/rocks/ mod_pubsub_serverinfo
             ynh_systemctl --service=$app --action="restart"
         fi
+        if ! prosodyctl list | grep -q ^mod_sasl_ssdp ; then
+            ynh_print_info "Installing mod_sasl_ssdp \"manually\" because it is not available in Debian Bookworm."
+            prosodyctl install --server=https://modules.prosody.im/rocks/ mod_sasl_ssdp
+            ynh_systemctl --service=$app --action="restart"
+        fi
     else
         if prosodyctl list | grep -q ^mod_cloud_notify_ ; then
             ynh_print_info "Uninstalling mod_cloud_notify_extensions that was previously installed \"manually\". It is now included in Debian."


### PR DESCRIPTION
Fixes #74.

Takes a stock install from **91% → 100%** on the [Compliance Suites 2023](https://compliance.conversations.im/), closing the four gaps this repo's `xmpp_compliance` file tracks, plus some TLS/SASL hardening. Tested on YunoHost 12.1.40.1 / Prosody 0.12.3.

## Compliance fixes (91% → 100%)
- **XEP-0157** — enable core `mod_server_contact_info` + uncomment the ready `contact_info` block.
- **XEP-0065** — add a `proxy65` component (+ port 5000, `proxy.` CNAME, disco item).
- **XEP-0368** — register the `_xmpps-client` / `_xmpp-*` SRV records **and** set `c2s_direct_tls_ssl`. The direct-TLS listener had *no* certificate (it falls back to the unset global `ssl`), so 5223 answered every handshake with a TLS alert — direct-TLS was effectively non-functional.
- **XEP-0485** — install `mod_pubsub_serverinfo` **and its `mod_server_info` dependency** (neither is in Bookworm's `prosody-modules`, and `prosodyctl install` does not pull the dep).

## Hardening (beyond the suite)
- **XEP-0368 s2s** — `s2s_direct_tls_ports = { 5270 }` + `s2s_direct_tls_ssl` + `_xmpps-server._tcp` SRV (completes direct-TLS both ways).
- **XEP-0474** — enable `mod_sasl_ssdp` (SASL SCRAM downgrade protection).

## Notes for reviewers
- SRV records are emitted with **relative** names — YunoHost's Porkbun registrar push doesn't zone-strip SRVs (double-domain → 400). Validated in `dns suggest`.
- The `mod_server_info` / `mod_pubsub_serverinfo` / `mod_sasl_ssdp` installs sit in the **Bookworm** branch of `_common.sh`; the Trixie else-branch removal should be extended if those get packaged.
- `scripts/upgrade`'s `yunohost service add … --needs_exposed_ports` lists client/client2/server but not the new proxy/server2 ports — harmless (the `[resources.ports]` block opens them), worth tidying.
- **Out of scope (needs Prosody 13.0):** SASL2 (XEP-0388) and modern channel binding (XEP-0440 `tls-exporter`) — `mod_sasl2` doesn't load on 0.12.
- The s2s direct-TLS and XEP-0474 bits are optional hardening — happy to split them out if you'd prefer the PR scoped to compliance only.
