### PR TITLE
Enable Prosody 13 SASL2 stack (SASL2 / Bind2 / FAST)

### DIFF
--- a/conf/domain.tpl.cfg.lua
+++ b/conf/domain.tpl.cfg.lua
@@ -16,6 +16,8 @@ VirtualHost "__DOMAIN__"
     "bosh";
     "websocket";
     "csi_battery_saver";
+    -- SASL2 stack (Prosody 13+ only; empty on Debian Bookworm / Prosody 0.12)
+    __SASL2_MODULES__
   }
 
   modules_disabled = {

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Prosody"
 description.en = "Modern XMPP communication server"
 description.fr = "Serveur de communication XMPP moderne"
 
-version = "0.12.4~ynh121"
+version = "0.12.4~ynh122"
 
 maintainers = ["yalh76", "anubister", "pitchum"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -31,6 +31,16 @@ _configure_prosody() {
     ynh_config_add --template="00.cfg.lua" --destination="/etc/prosody/conf.avail/00.cfg.lua"
     ln -srf /etc/prosody/conf.avail/00.cfg.lua /etc/prosody/conf.d/
 
+    # SASL2 stack (XEP-0388 SASL2, XEP-0386 Bind2, XEP-0484 FAST + inline stream
+    # management/resumption). These modules ship with Prosody 13; they do not
+    # exist on the Prosody 0.12 that Debian Bookworm provides, so only enable
+    # them on newer Debian (Trixie and later).
+    if grep -q "^VERSION_CODENAME=bookworm" /etc/os-release ; then
+        sasl2_modules=""
+    else
+        sasl2_modules='"sasl2"; "sasl2_bind2"; "sasl2_sm"; "sasl2_fast";'
+    fi
+
     # Add domain configuration
     ynh_config_add --template="domain.tpl.cfg.lua" --destination="/etc/prosody/conf.avail/${domain}.cfg.lua"
     ln -srf /etc/prosody/conf.avail/${domain}.cfg.lua /etc/prosody/conf.d/


### PR DESCRIPTION
## What

Enable the Prosody 13 **SASL2** stack in the per-domain config:

- `mod_sasl2` — SASL2 (XEP-0388)
- `mod_sasl2_bind2` — Bind 2.0 (XEP-0386)
- `mod_sasl2_sm` — inline Stream Management / resumption
- `mod_sasl2_fast` — FAST fast reauthentication (XEP-0484)

## Why

These are Prosody 13's modern connection-setup features (single round-trip
SASL2 + inline bind/resume, FAST reauth tokens, and — with a SCRAM-capable
auth backend — channel binding via `tls-exporter` / RFC 9266). They ship
with Prosody 13 but weren't enabled by the app.

## Version safety

The modules don't exist on the Prosody 0.12 that Debian **Bookworm** ships,
so they are only added on Trixie and later, reusing the same
`VERSION_CODENAME=bookworm` check already present in
`_ensure_extra_modules_are_installed`. On Bookworm the `__SASL2_MODULES__`
placeholder expands to nothing (a comment + blank line inside
`modules_enabled`, which is valid Lua).

## Tested

On YunoHost 13 / Debian Trixie (Prosody 13.0.1). With these modules
enabled, the server's post-STARTTLS stream features advertise:

- `urn:xmpp:sasl:2` (SASL2)
- `urn:xmpp:bind:0` (Bind2)
- `<sasl-channel-binding>` offering `tls-exporter`
- inline `urn:xmpp:sm:3` and `urn:xmpp:csi:0`

(Verified by probing the advertised `<stream:features>`. Note: *usable*
SCRAM channel binding additionally requires a SCRAM-capable auth backend;
with YunoHost's LDAP auth only `PLAIN` is offered today — a separate
concern from this change.)
